### PR TITLE
adding the missing docstrings for the fraction_below_threshold function

### DIFF
--- a/ccvm/solution.py
+++ b/ccvm/solution.py
@@ -91,7 +91,7 @@ class Solution:
 
             Args:
                 gap_tensor (torch.Tensor): The tensor of the percentage distances of the found
-                objective values from the optimal value of the problem objective function.
+                    objective values from the optimal value of the problem objective function.
                 threshold (float): The specified percentage gap
 
             Returns:


### PR DESCRIPTION
Added the missing docstrings for the `fraction_below_threshold function` function in `solution.py`.
The rest of the docstrings in the issue are already there. 