### PR TITLE
Reduce redundant code duplication in the solve methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Algorithm parameter classes have been added to `ccvm_simulators.solvers.algorithms` to allow users to specify the `algorithm_parameters`.
 
 ### Changed
+- Moved the update code segment for `solution` object from `_solve()` and `_solve_adam()` to `__call__()` in order to reduce code duplication in `LangevinSolver`, `DLSolver`, and `MFSolver`.
 - Updated internal data handling that have improved performance and reduced memory usage.
 - Updated data structure for new problem instance file:
 	-- Additional fields (`best_sol`, `sol_time_bfgs`, and `num_frac_values`) are added so that additional values in the first line can be extracted properly,
@@ -32,7 +33,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Increased test coverage, especially with respect to the Problem and Solution classes.
 
 ### Changed
-- Moved the update code segment for `solution` object from `_solve()` and `_solve_adam()` to `__call__()` in order to reduce code duplication in `LangevinSolver`, `DLSolver`, and `MFSolver`.
 - Updated the MF Solver and DL Solver algorithms to better account for the enforced saturation value (S).
 - Improved and fixed some issues in the DL and MF solvers to improve performance.
 - Modified the gradient of the objective function in the MFSolver to implement a linear function of variables by default. This enhances the performance of the solver.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Increased test coverage, especially with respect to the Problem and Solution classes.
 
 ### Changed
-- Refactor return part of `_solver()`, `_solve_adam()`, and `__call__()` to avoid code duplication in `LangevinSolver`, `DLSolver`, and `MFSolver`.
+- Moved the update code segment for `solution` object from `_solve()` and `_solve_adam()` to `__call__()` in order to reduce code duplication in `LangevinSolver`, `DLSolver`, and `MFSolver`.
 - Updated the MF Solver and DL Solver algorithms to better account for the enforced saturation value (S).
 - Improved and fixed some issues in the DL and MF solvers to improve performance.
 - Modified the gradient of the objective function in the MFSolver to implement a linear function of variables by default. This enhances the performance of the solver.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Increased test coverage, especially with respect to the Problem and Solution classes.
 
 ### Changed
+- Refactor return part of `_solver()`, `_solve_adam()`, and `__call__()` to avoid code duplication in `LangevinSolver`, `DLSolver`, and `MFSolver`.
 - Updated the MF Solver and DL Solver algorithms to better account for the enforced saturation value (S).
 - Improved and fixed some issues in the DL and MF solvers to improve performance.
 - Modified the gradient of the objective function in the MFSolver to implement a linear function of variables by default. This enhances the performance of the solver.

--- a/ccvm_simulators/solvers/dl_solver.py
+++ b/ccvm_simulators/solvers/dl_solver.py
@@ -255,7 +255,7 @@ class DLSolver(CCVMSolver):
 
         Returns:
             c, s (tensor): random variables 
-            c_sample, s_sample (tensor): random sample [needs attention] 
+            c_sample, s_sample (tensor): variables for random samples 
             solve_time (float): Elapsed time 
             S (float): Saturation bound
         """
@@ -424,7 +424,7 @@ class DLSolver(CCVMSolver):
 
         Returns:
             c, s (tensor): random variables 
-            c_sample, s_sample (tensor): random sample [needs attention] 
+            c_sample, s_sample (tensor): variables for random samples 
             solve_time (float): Elapsed time 
             S (float): Saturation bound
         """

--- a/ccvm_simulators/solvers/dl_solver.py
+++ b/ccvm_simulators/solvers/dl_solver.py
@@ -231,7 +231,6 @@ class DLSolver(CCVMSolver):
     def _solve(
         self,
         instance,
-        post_processor=None,
         pump_rate_flag=True,
         g=0.05,
         evolution_step_size=None,
@@ -241,8 +240,6 @@ class DLSolver(CCVMSolver):
 
         Args:
             instance (ProblemInstance): The problem instance to solve.
-            post_processor (str): The name of the post processor to use to process the results of the solver.
-                None if no post processing is desired. Defaults to None.
             pump_rate_flag (bool): Whether or not to scale the pump rate based on the
             iteration number. If False, the pump rate will be 1.0. Defaults to True.
             g (float): The nonlinearity coefficient. Defaults to 0.05.
@@ -402,7 +399,6 @@ class DLSolver(CCVMSolver):
         self,
         instance,
         hyperparameters,
-        post_processor=None,
         pump_rate_flag=True,
         g=0.05,
         evolution_step_size=None,
@@ -413,8 +409,6 @@ class DLSolver(CCVMSolver):
         Args:
             instance (ProblemInstance): The problem instance to solve.
             hyperparameters (dict): Hyperparameters for Adam algorithm.
-            post_processor (str): The name of the post processor to use to process the results of the solver.
-                None if no post processing is desired. Defaults to None.
             pump_rate_flag (bool): Whether or not to scale the pump rate based on the
             iteration number. If False, the pump rate will be 1.0. Defaults to True.
             g (float): The nonlinearity coefficient. Defaults to 0.05.
@@ -709,7 +703,6 @@ class DLSolver(CCVMSolver):
             # Use the original DL solver
             c, s, c_sample, s_sample, solve_time, S = self._solve(
                 instance,
-                post_processor,
                 pump_rate_flag,
                 g,
                 evolution_step_size,
@@ -720,7 +713,6 @@ class DLSolver(CCVMSolver):
             c, s, c_sample, s_sample, solve_time, S = self._solve_adam(
                 instance,
                 algorithm_parameters.to_dict(),
-                post_processor,
                 pump_rate_flag,
                 g,
                 evolution_step_size,

--- a/ccvm_simulators/solvers/dl_solver.py
+++ b/ccvm_simulators/solvers/dl_solver.py
@@ -299,6 +299,8 @@ class DLSolver(CCVMSolver):
         # Start the timer for the solve
         solve_time_start = time.time()
 
+        c_sample = None # Make it global
+        s_sample = None # Make it global
         if evolution_step_size:
             # Check that the value is valid
             if evolution_step_size < 1:
@@ -389,67 +391,9 @@ class DLSolver(CCVMSolver):
 
         # Stop the timer for the solve
         solve_time = time.time() - solve_time_start
-
-        # Run the post processor on the results, if specified
-        if post_processor:
-            post_processor_object = PostProcessorFactory.create_postprocessor(
-                post_processor
-            )
-
-            problem_variables = post_processor_object.postprocess(
-                self.change_variables(c, S), self.q_matrix, self.v_vector
-            )
-            pp_time = post_processor_object.pp_time
-        else:
-            problem_variables = c
-            pp_time = 0.0
-
-        # Calculate the objective value
-        # Perform a change of variables to enforce the box constraints
-        confs = self.change_variables(problem_variables, S)
-        objval = instance.compute_energy(confs)
-
-        # TODO: Move the rest of the code to DLSolver.__call__() and update the return accordingly
-
-        if evolution_step_size:
-            # Write samples to file
-            # Overwrite file if it exists
-            open(evolution_file, "w")
-
-            # Get the indices of the best objective values over the sampled iterations
-            # to use to get and save the best sampled values of c and s
-            batch_index = torch.argmax(-objval)
-            with open(evolution_file, "a") as evolution_file_obj:
-                self._append_samples_to_file(
-                    c_sample=c_sample[batch_index],
-                    s_sample=s_sample[batch_index],
-                    evolution_file_object=evolution_file_obj,
-                )
-
-        solution = Solution(
-            problem_size=problem_size,
-            batch_size=batch_size,
-            instance_name=instance.name,
-            iterations=iterations,
-            objective_values=objval,
-            solve_time=solve_time,
-            pp_time=pp_time,
-            optimal_value=instance.optimal_sol,
-            best_value=instance.best_sol,
-            num_frac_values=instance.num_frac_values,
-            solution_vector=instance.solution_vector,
-            variables={
-                "problem_variables": problem_variables,
-                "s": s,
-            },
-            device=device,
-        )
-
-        # Add evolution filename to solution if it was generated
-        if evolution_step_size:
-            solution.evolution_file = evolution_file
-
-        return solution
+        
+        return c, s, c_sample, s_sample, solve_time
+        
 
     def _solve_adam(
         self,
@@ -523,7 +467,9 @@ class DLSolver(CCVMSolver):
 
         # Start the timer for the solve
         solve_time_start = time.time()
-
+        
+        c_sample = None # Make it global
+        s_sample = None # Make it global
         if evolution_step_size:
             # Check that the value is valid
             if evolution_step_size < 1:
@@ -713,67 +659,9 @@ class DLSolver(CCVMSolver):
 
         # Stop the timer for the solve
         solve_time = time.time() - solve_time_start
-
-        # Run the post processor on the results, if specified
-        if post_processor:
-            post_processor_object = PostProcessorFactory.create_postprocessor(
-                post_processor
-            )
-
-            problem_variables = post_processor_object.postprocess(
-                self.change_variables(c, S), self.q_matrix, self.v_vector
-            )
-            pp_time = post_processor_object.pp_time
-        else:
-            problem_variables = c
-            pp_time = 0.0
-
-        # Calculate the objective value
-        # Perform a change of variables to enforce the box constraints
-        confs = self.change_variables(problem_variables, S)
-        objval = instance.compute_energy(confs)
-
-        # TODO: Move the rest of the code to DLSolver.__call__() and update the return accordingly
-
-        if evolution_step_size:
-            # Write samples to file
-            # Overwrite file if it exists
-            open(evolution_file, "w")
-
-            # Get the indices of the best objective values over the sampled iterations
-            # to use to get and save the best sampled values of c and s
-            batch_index = torch.argmax(-objval)
-            with open(evolution_file, "a") as evolution_file_obj:
-                self._append_samples_to_file(
-                    c_sample=c_sample[batch_index],
-                    s_sample=s_sample[batch_index],
-                    evolution_file_object=evolution_file_obj,
-                )
-
-        solution = Solution(
-            problem_size=problem_size,
-            batch_size=batch_size,
-            instance_name=instance.name,
-            iterations=iterations,
-            objective_values=objval,
-            solve_time=solve_time,
-            pp_time=pp_time,
-            optimal_value=instance.optimal_sol,
-            best_value=instance.best_sol,
-            num_frac_values=instance.num_frac_values,
-            solution_vector=instance.solution_vector,
-            variables={
-                "problem_variables": problem_variables,
-                "s": s,
-            },
-            device=device,
-        )
-
-        # Add evolution filename to solution if it was generated
-        if evolution_step_size:
-            solution.evolution_file = evolution_file
-
-        return solution
+        
+        return c, s, c_sample, s_sample, solve_time
+    
 
     def __call__(
         self,
@@ -811,12 +699,9 @@ class DLSolver(CCVMSolver):
             solution (Solution): The solution to the problem instance.
         """
 
-        # TODO: Get the solution object from DLSolver._solve() or _solve_adam()
-        #      and return the outcomes properly
-
         if algorithm_parameters is None:
             # Use the original DL solver
-            return self._solve(
+            c, s, c_sample, s_sample, solve_time = self._solve(
                 instance,
                 post_processor,
                 pump_rate_flag,
@@ -826,7 +711,7 @@ class DLSolver(CCVMSolver):
             )
         elif isinstance(algorithm_parameters, AdamParameters):
             # Use the DL solver with the Adam algorithm
-            return self._solve_adam(
+            c, s, c_sample, s_sample, solve_time = self._solve_adam(
                 instance,
                 algorithm_parameters.to_dict(),
                 post_processor,
@@ -839,3 +724,63 @@ class DLSolver(CCVMSolver):
             raise ValueError(
                 f"Solver option type {type(algorithm_parameters)} is not supported."
             )
+        
+        # Run the post processor on the results, if specified
+        if post_processor:
+            post_processor_object = PostProcessorFactory.create_postprocessor(
+                post_processor
+            )
+
+            problem_variables = post_processor_object.postprocess(
+                self.change_variables(c, self.S), self.q_matrix, self.v_vector
+            )
+            pp_time = post_processor_object.pp_time
+        else:
+            problem_variables = c
+            pp_time = 0.0
+
+        # Calculate the objective value
+        # Perform a change of variables to enforce the box constraints
+        confs = self.change_variables(problem_variables, self.S)
+        objval = instance.compute_energy(confs)
+
+        if evolution_step_size:
+            # Write samples to file
+            # Overwrite file if it exists
+            open(evolution_file, "w")
+
+            # Get the indices of the best objective values over the sampled iterations
+            # to use to get and save the best sampled values of c and s
+            batch_index = torch.argmax(-objval)
+            with open(evolution_file, "a") as evolution_file_obj:
+                self._append_samples_to_file(
+                    c_sample=c_sample[batch_index],
+                    s_sample=s_sample[batch_index],
+                    evolution_file_object=evolution_file_obj,
+                )
+
+        solution = Solution(
+            problem_size=instance.problem_size,
+            batch_size=self.batch_size,
+            instance_name=instance.name,
+            iterations=self.parameter_key[instance.problem_size]["iterations"],
+            objective_values=objval,
+            solve_time=solve_time,
+            pp_time=pp_time,
+            optimal_value=instance.optimal_sol,
+            best_value=instance.best_sol,
+            num_frac_values=instance.num_frac_values,
+            solution_vector=instance.solution_vector,
+            variables={
+                "problem_variables": problem_variables,
+                "s": s,
+            },
+            device=self.device,
+        )
+
+        # Add evolution filename to solution if it was generated
+        if evolution_step_size:
+            solution.evolution_file = evolution_file
+
+        return solution
+

--- a/ccvm_simulators/solvers/dl_solver.py
+++ b/ccvm_simulators/solvers/dl_solver.py
@@ -299,8 +299,8 @@ class DLSolver(CCVMSolver):
         # Start the timer for the solve
         solve_time_start = time.time()
 
-        c_sample = None # Make it global
-        s_sample = None # Make it global
+        c_sample = None 
+        s_sample = None 
         if evolution_step_size:
             # Check that the value is valid
             if evolution_step_size < 1:
@@ -468,8 +468,8 @@ class DLSolver(CCVMSolver):
         # Start the timer for the solve
         solve_time_start = time.time()
         
-        c_sample = None # Make it global
-        s_sample = None # Make it global
+        c_sample = None 
+        s_sample = None 
         if evolution_step_size:
             # Check that the value is valid
             if evolution_step_size < 1:

--- a/ccvm_simulators/solvers/langevin_solver.py
+++ b/ccvm_simulators/solvers/langevin_solver.py
@@ -278,7 +278,7 @@ class LangevinSolver(CCVMSolver):
         # Start the timer for the solve
         solve_time_start = time.time()
 
-        c_sample = None # Make the variable global
+        c_sample = None # Make it global
         if evolution_step_size:
             # Check that the value is valid
             if evolution_step_size < 1:
@@ -529,39 +529,6 @@ class LangevinSolver(CCVMSolver):
         solve_time = time.time() - solve_time_start
         
         return c, c_sample, solve_time
-        
-        # # Run the post processor on the results, if specified
-        # if post_processor:
-        #     post_processor_object = PostProcessorFactory.create_postprocessor(
-        #         post_processor
-        #     )
-        #
-        #     problem_variables = post_processor_object.postprocess(
-        #         self.change_variables(c, S), self.q_matrix, self.v_vector
-        #     )
-        #     pp_time = post_processor_object.pp_time
-        # else:
-        #     problem_variables = c
-        #     pp_time = 0.0
-        #
-        # # Calculate the objective value
-        # objval = instance.compute_energy(problem_variables)
-        #
-        # if evolution_step_size:
-        #     # Write samples to file
-        #     # Overwrite file if it exists
-        #     open(evolution_file, "w")
-        #
-        #     # Get the indices of the best objective values over the sampled iterations
-        #     # to use to get and save the best sampled values of c and s
-        #     batch_index = torch.argmax(-objval)
-        #     with open(evolution_file, "a") as evolution_file_obj:
-        #         self._append_samples_to_file(
-        #             c_sample=c_sample[batch_index],
-        #             evolution_file_object=evolution_file_obj,
-        #         )
-        #
-        # return objval, problem_variables, solve_time, pp_time
 
     def __call__(
         self,

--- a/ccvm_simulators/solvers/langevin_solver.py
+++ b/ccvm_simulators/solvers/langevin_solver.py
@@ -340,9 +340,6 @@ class LangevinSolver(CCVMSolver):
         # Stop the timer for the solve
         solve_time = time.time() - solve_time_start
 
-        # TODO: Similar to DLSolver, move the rest of the code to the LangevinSolver.__call__()
-        #       and update the return accordingly
-
         # Run the post processor on the results, if specified
         if post_processor:
             post_processor_object = PostProcessorFactory.create_postprocessor(
@@ -579,10 +576,6 @@ class LangevinSolver(CCVMSolver):
 
         # Stop the timer for the solve
         solve_time = time.time() - solve_time_start
-
-        # TODO: Similar in DLSolver._solve() and DLSolver._solve_adam(),
-        #       move the rest of the code segments to the LangevinSolver.__call__()
-        #       and update the return accordingly
 
         # Run the post processor on the results, if specified
         if post_processor:

--- a/ccvm_simulators/solvers/langevin_solver.py
+++ b/ccvm_simulators/solvers/langevin_solver.py
@@ -214,7 +214,6 @@ class LangevinSolver(CCVMSolver):
     def _solve(
         self,
         instance,
-        post_processor=None,
         evolution_step_size=None,
         evolution_file=None,
     ):
@@ -222,8 +221,6 @@ class LangevinSolver(CCVMSolver):
 
         Args:
             instance (ProblemInstance): The problem instance to solve.
-            post_processor (str): The name of the post processor to use to process the results of the solver.
-                None if no post processing is desired. Defaults to None.
             evolution_step_size (int): If set, the c/s values will be sampled once
                 per number of iterations equivalent to the value of this variable.
                 At the end of the solve process, the best batch of sampled values
@@ -350,7 +347,6 @@ class LangevinSolver(CCVMSolver):
         self,
         instance,
         hyperparameters,
-        post_processor=None,
         evolution_step_size=None,
         evolution_file=None,
     ):
@@ -359,8 +355,6 @@ class LangevinSolver(CCVMSolver):
         Args:
             instance (ProblemInstance): The problem instance to solve.
             hyperparameters (dict): Hyperparameters for adam algorithm.
-            post_processor (str): The name of the post processor to use to process the results of the solver.
-                None if no post processing is desired. Defaults to None.
             evolution_step_size (int): If set, the c/s values will be sampled once
                 per number of iterations equivalent to the value of this variable.
                 At the end of the solve process, the best batch of sampled values
@@ -570,14 +564,13 @@ class LangevinSolver(CCVMSolver):
         if algorithm_parameters is None:
             # Use the original Langevin solver
             c, c_sample, solve_time, S = self._solve(
-                instance, post_processor, evolution_step_size, evolution_file
+                instance, evolution_step_size, evolution_file
             )
         elif isinstance(algorithm_parameters, AdamParameters):
             # Use the Langevin solver with the Adam algorithm
             c, c_sample, solve_time, S = self._solve_adam(
                 instance,
                 algorithm_parameters.to_dict(),
-                post_processor,
                 evolution_step_size,
                 evolution_file,
             )

--- a/ccvm_simulators/solvers/langevin_solver.py
+++ b/ccvm_simulators/solvers/langevin_solver.py
@@ -588,28 +588,8 @@ class LangevinSolver(CCVMSolver):
                     c_sample=c_sample[batch_index],
                     evolution_file_object=evolution_file_obj,
                 )
-
-        solution = Solution(
-            problem_size=problem_size,
-            batch_size=batch_size,
-            instance_name=instance.name,
-            iterations=iterations,
-            objective_values=objval,
-            solve_time=solve_time,
-            pp_time=pp_time,
-            optimal_value=instance.optimal_sol,
-            best_value=instance.best_sol,
-            num_frac_values=instance.num_frac_values,
-            solution_vector=instance.solution_vector,
-            variables={"problem_variables": problem_variables},
-            device=device,
-        )
-
-        # Add evolution filename to solution if it was generated
-        if evolution_step_size:
-            solution.evolution_file = evolution_file
-
-        return solution
+    
+        return objval, problem_variables, solve_time, pp_time
 
     def __call__(
         self,

--- a/ccvm_simulators/solvers/langevin_solver.py
+++ b/ccvm_simulators/solvers/langevin_solver.py
@@ -278,7 +278,7 @@ class LangevinSolver(CCVMSolver):
         # Start the timer for the solve
         solve_time_start = time.time()
 
-        c_sample = None # Make it global
+        c_sample = None 
         if evolution_step_size:
             # Check that the value is valid
             if evolution_step_size < 1:
@@ -411,7 +411,7 @@ class LangevinSolver(CCVMSolver):
         # Start the timer for the solve
         solve_time_start = time.time()
 
-        c_sample = None # Make the variable global
+        c_sample = None 
         if evolution_step_size:
             # Check that the value is valid
             if evolution_step_size < 1:

--- a/ccvm_simulators/solvers/langevin_solver.py
+++ b/ccvm_simulators/solvers/langevin_solver.py
@@ -233,7 +233,7 @@ class LangevinSolver(CCVMSolver):
 
         Returns:
             c (tensor): random variable 
-            c_sample (tensor):  
+            c_sample (tensor): variable for random sample 
             solve_time (float): Elapsed time 
             S (float): Saturation bound
         """
@@ -367,7 +367,7 @@ class LangevinSolver(CCVMSolver):
 
         Returns:
             c (tensor): random variable 
-            c_sample (tensor):  
+            c_sample (tensor):  variable for random sample 
             solve_time (float): Elapsed time 
             S (float): Saturation bound
         """

--- a/ccvm_simulators/solvers/langevin_solver.py
+++ b/ccvm_simulators/solvers/langevin_solver.py
@@ -235,7 +235,10 @@ class LangevinSolver(CCVMSolver):
                 Defaults to None, which generates a filename based on the problem instance name.
 
         Returns:
-            solution (Solution): The solution to the problem instance.
+            c (tensor): random variable 
+            c_sample (tensor):  
+            solve_time (float): Elapsed time 
+            S (float): Saturation bound
         """
         # If the instance and the solver don't specify the same device type, raise
         # an error
@@ -341,7 +344,7 @@ class LangevinSolver(CCVMSolver):
         # Stop the timer for the solve
         solve_time = time.time() - solve_time_start
         
-        return c, c_sample, solve_time         
+        return c, c_sample, solve_time, S      
 
     def _solve_adam(
         self,
@@ -369,7 +372,10 @@ class LangevinSolver(CCVMSolver):
                 Defaults to None, which generates a filename based on the problem instance name.
 
         Returns:
-            solution (Solution): The solution to the problem instance.
+            c (tensor): random variable 
+            c_sample (tensor):  
+            solve_time (float): Elapsed time 
+            S (float): Saturation bound
         """
         # If the instance and the solver don't specify the same device type, raise
         # an error
@@ -528,7 +534,7 @@ class LangevinSolver(CCVMSolver):
         # Stop the timer for the solve
         solve_time = time.time() - solve_time_start
         
-        return c, c_sample, solve_time
+        return c, c_sample, solve_time, S
 
     def __call__(
         self,
@@ -563,12 +569,12 @@ class LangevinSolver(CCVMSolver):
         """
         if algorithm_parameters is None:
             # Use the original Langevin solver
-            c, c_sample, solve_time = self._solve(
+            c, c_sample, solve_time, S = self._solve(
                 instance, post_processor, evolution_step_size, evolution_file
             )
         elif isinstance(algorithm_parameters, AdamParameters):
             # Use the Langevin solver with the Adam algorithm
-            c, c_sample, solve_time = self._solve_adam(
+            c, c_sample, solve_time, S = self._solve_adam(
                 instance,
                 algorithm_parameters.to_dict(),
                 post_processor,

--- a/ccvm_simulators/solvers/mf_solver.py
+++ b/ccvm_simulators/solvers/mf_solver.py
@@ -263,7 +263,6 @@ class MFSolver(CCVMSolver):
     def _solve(
         self,
         instance,
-        post_processor=None,
         g=0.01,
         pump_rate_flag=True,
         evolution_step_size=None,
@@ -274,8 +273,6 @@ class MFSolver(CCVMSolver):
 
         Args:
             instance (boxqp.boxqp.ProblemInstance): The problem to solve.
-            post_processor (str): The name of the post processor to use to process
-                the results of the solver. None if no post processing is desired.
             g (float, optional): The nonlinearity coefficient. Defaults to 0.01
             pump_rate_flag (bool, optional): Whether or not to scale the pump rate
                 based on the iteration number. If False, the pump rate will be 1.0.
@@ -435,7 +432,6 @@ class MFSolver(CCVMSolver):
         self,
         instance,
         hyperparameters,
-        post_processor=None,
         g=0.01,
         pump_rate_flag=True,
         evolution_step_size=None,
@@ -447,8 +443,6 @@ class MFSolver(CCVMSolver):
         Args:
             instance (boxqp.boxqp.ProblemInstance): The problem to solve.
             hyperparameters (dict): Hyperparameters for adam algorithm.
-            post_processor (str): The name of the post processor to use to process
-                the results of the solver. None if no post processing is desired.
             g (float, optional): The nonlinearity coefficient. Defaults to 0.01
             pump_rate_flag (bool, optional): Whether or not to scale the pump rate
                 based on the iteration number. If False, the pump rate will be 1.0.
@@ -713,7 +707,6 @@ class MFSolver(CCVMSolver):
             # Use the original MF solver
             mu, mu_tilde, sigma, mu_sample, sigma_sample, solve_time, S = self._solve(
                 instance,
-                post_processor,
                 g,
                 pump_rate_flag,
                 evolution_step_size,
@@ -724,7 +717,6 @@ class MFSolver(CCVMSolver):
             mu, mu_tilde, sigma, mu_sample, sigma_sample, solve_time, S = self._solve_adam(
                 instance,
                 algorithm_parameters.to_dict(),
-                post_processor,
                 g,
                 pump_rate_flag,
                 evolution_step_size,

--- a/ccvm_simulators/solvers/mf_solver.py
+++ b/ccvm_simulators/solvers/mf_solver.py
@@ -335,6 +335,8 @@ class MFSolver(CCVMSolver):
         # Start timing the solve process
         solve_time_start = time.time()
 
+        mu_sample = None # Make it global variable
+        sigma_sample = None # Make it global variable
         if evolution_step_size:
             # Check that the value is valid
             if evolution_step_size < 1:
@@ -422,69 +424,68 @@ class MFSolver(CCVMSolver):
         mu_tilde = self.fit_to_constraints(mu_tilde, -S, S)
 
         solve_time = time.time() - solve_time_start
+        
+        return mu, mu_tilde, sigma, mu_sample, sigma_sample, solve_time, S 
 
-        # TODO: Similar to DLSolver, move the rest of the code to the MFSolver.__call__()
-        #       and update the return accordingly
-
-        # Run the post processor on the results, if specified
-        if post_processor:
-            post_processor_object = PostProcessorFactory.create_postprocessor(
-                post_processor
-            )
-
-            problem_variables = post_processor_object.postprocess(
-                self.change_variables(mu_tilde, S),
-                self.q_matrix,
-                self.v_vector,
-                device=device,
-            )
-            pp_time = post_processor_object.pp_time
-        else:
-            problem_variables = self.change_variables(mu_tilde, S)
-            pp_time = 0.0
-
-        objval = instance.compute_energy(problem_variables)
-
-        if evolution_step_size:
-            # Write samples to file
-            # Overwrite file if it exists
-            open(evolution_file, "w")
-
-            # Get the indices of the best objective values over the sampled iterations
-            # to use to get and save the best sampled values of mu and sigma
-            batch_index = torch.argmax(-objval)
-            with open(evolution_file, "a") as evolution_file_obj:
-                self._append_samples_to_file(
-                    mu_sample=mu_sample[batch_index],
-                    sigma_sample=sigma_sample[batch_index],
-                    evolution_file_object=evolution_file_obj,
-                )
-
-        solution = Solution(
-            problem_size=problem_size,
-            batch_size=batch_size,
-            instance_name=instance.name,
-            iterations=iterations,
-            objective_values=objval,
-            solve_time=solve_time,
-            pp_time=pp_time,
-            optimal_value=instance.optimal_sol,
-            best_value=instance.best_sol,
-            num_frac_values=instance.num_frac_values,
-            solution_vector=instance.solution_vector,
-            variables={
-                "problem_variables": problem_variables,
-                "mu": mu,
-                "sigma": sigma,
-            },
-            device=device,
-        )
-
-        # Add evolution filename to solution if it was generated
-        if evolution_step_size:
-            solution.evolution_file = evolution_file
-
-        return solution
+        # # Run the post processor on the results, if specified
+        # if post_processor:
+        #     post_processor_object = PostProcessorFactory.create_postprocessor(
+        #         post_processor
+        #     )
+        #
+        #     problem_variables = post_processor_object.postprocess(
+        #         self.change_variables(mu_tilde, S),
+        #         self.q_matrix,
+        #         self.v_vector,
+        #         device=device,
+        #     )
+        #     pp_time = post_processor_object.pp_time
+        # else:
+        #     problem_variables = self.change_variables(mu_tilde, S)
+        #     pp_time = 0.0
+        #
+        # objval = instance.compute_energy(problem_variables)
+        #
+        # if evolution_step_size:
+        #     # Write samples to file
+        #     # Overwrite file if it exists
+        #     open(evolution_file, "w")
+        #
+        #     # Get the indices of the best objective values over the sampled iterations
+        #     # to use to get and save the best sampled values of mu and sigma
+        #     batch_index = torch.argmax(-objval)
+        #     with open(evolution_file, "a") as evolution_file_obj:
+        #         self._append_samples_to_file(
+        #             mu_sample=mu_sample[batch_index],
+        #             sigma_sample=sigma_sample[batch_index],
+        #             evolution_file_object=evolution_file_obj,
+        #         )
+        #
+        # solution = Solution(
+        #     problem_size=problem_size,
+        #     batch_size=batch_size,
+        #     instance_name=instance.name,
+        #     iterations=iterations,
+        #     objective_values=objval,
+        #     solve_time=solve_time,
+        #     pp_time=pp_time,
+        #     optimal_value=instance.optimal_sol,
+        #     best_value=instance.best_sol,
+        #     num_frac_values=instance.num_frac_values,
+        #     solution_vector=instance.solution_vector,
+        #     variables={
+        #         "problem_variables": problem_variables,
+        #         "mu": mu,
+        #         "sigma": sigma,
+        #     },
+        #     device=device,
+        # )
+        #
+        # # Add evolution filename to solution if it was generated
+        # if evolution_step_size:
+        #     solution.evolution_file = evolution_file
+        #
+        # return solution
 
     def _solve_adam(
         self,
@@ -563,6 +564,8 @@ class MFSolver(CCVMSolver):
         # Start timing the solve process
         solve_time_start = time.time()
 
+        mu_sample = None # Make it global variable
+        sigma_sample = None # Make it global variable
         if evolution_step_size:
             # Check that the value is valid
             if evolution_step_size < 1:
@@ -718,68 +721,67 @@ class MFSolver(CCVMSolver):
 
         solve_time = time.time() - solve_time_start
 
-        # TODO: Similar to the solver methos in LangevinSolver and DLSolver
-        #       move the rest of the statements and update the return accordingly
-
-        # Run the post processor on the results, if specified
-        if post_processor:
-            post_processor_object = PostProcessorFactory.create_postprocessor(
-                post_processor
-            )
-
-            problem_variables = post_processor_object.postprocess(
-                self.change_variables(mu_tilde, S),
-                self.q_matrix,
-                self.v_vector,
-                device=device,
-            )
-            pp_time = post_processor_object.pp_time
-        else:
-            problem_variables = self.change_variables(mu_tilde, S)
-            pp_time = 0.0
-
-        objval = instance.compute_energy(problem_variables)
-
-        if evolution_step_size:
-            # Write samples to file
-            # Overwrite file if it exists
-            open(evolution_file, "w")
-
-            # Get the indices of the best objective values over the sampled iterations
-            # to use to get and save the best sampled values of mu and sigma
-            batch_index = torch.argmax(-objval)
-            with open(evolution_file, "a") as evolution_file_obj:
-                self._append_samples_to_file(
-                    mu_sample=mu_sample[batch_index],
-                    sigma_sample=sigma_sample[batch_index],
-                    evolution_file_object=evolution_file_obj,
-                )
-
-        solution = Solution(
-            problem_size=problem_size,
-            batch_size=batch_size,
-            instance_name=instance.name,
-            iterations=iterations,
-            objective_values=objval,
-            solve_time=solve_time,
-            pp_time=pp_time,
-            optimal_value=instance.optimal_sol,
-            best_value=instance.best_sol,
-            num_frac_values=instance.num_frac_values,
-            solution_vector=instance.solution_vector,
-            variables={
-                "problem_variables": problem_variables,
-                "mu": mu,
-                "sigma": sigma,
-            },
-            device=device,
-        )
-
-        # Add evolution filename to solution if it was generated
-        if evolution_step_size:
-            solution.evolution_file = evolution_file
-
-        return solution
+        return mu, mu_tilde, sigma, mu_sample, sigma_sample, solve_time, S
+    
+        # # Run the post processor on the results, if specified
+        # if post_processor:
+        #     post_processor_object = PostProcessorFactory.create_postprocessor(
+        #         post_processor
+        #     )
+        #
+        #     problem_variables = post_processor_object.postprocess(
+        #         self.change_variables(mu_tilde, S),
+        #         self.q_matrix,
+        #         self.v_vector,
+        #         device=device,
+        #     )
+        #     pp_time = post_processor_object.pp_time
+        # else:
+        #     problem_variables = self.change_variables(mu_tilde, S)
+        #     pp_time = 0.0
+        #
+        # objval = instance.compute_energy(problem_variables)
+        #
+        # if evolution_step_size:
+        #     # Write samples to file
+        #     # Overwrite file if it exists
+        #     open(evolution_file, "w")
+        #
+        #     # Get the indices of the best objective values over the sampled iterations
+        #     # to use to get and save the best sampled values of mu and sigma
+        #     batch_index = torch.argmax(-objval)
+        #     with open(evolution_file, "a") as evolution_file_obj:
+        #         self._append_samples_to_file(
+        #             mu_sample=mu_sample[batch_index],
+        #             sigma_sample=sigma_sample[batch_index],
+        #             evolution_file_object=evolution_file_obj,
+        #         )
+        #
+        # solution = Solution(
+        #     problem_size=problem_size,
+        #     batch_size=batch_size,
+        #     instance_name=instance.name,
+        #     iterations=iterations,
+        #     objective_values=objval,
+        #     solve_time=solve_time,
+        #     pp_time=pp_time,
+        #     optimal_value=instance.optimal_sol,
+        #     best_value=instance.best_sol,
+        #     num_frac_values=instance.num_frac_values,
+        #     solution_vector=instance.solution_vector,
+        #     variables={
+        #         "problem_variables": problem_variables,
+        #         "mu": mu,
+        #         "sigma": sigma,
+        #     },
+        #     device=device,
+        # )
+        #
+        # # Add evolution filename to solution if it was generated
+        # if evolution_step_size:
+        #     solution.evolution_file = evolution_file
+        #
+        # return solution
 
     def __call__(
         self,
@@ -821,7 +823,7 @@ class MFSolver(CCVMSolver):
         """
         if algorithm_parameters is None:
             # Use the original MF solver
-            return self._solve(
+            mu, mu_tilde, sigma, mu_sample, sigma_sample, solve_time, S = self._solve(
                 instance,
                 post_processor,
                 g,
@@ -831,7 +833,7 @@ class MFSolver(CCVMSolver):
             )
         elif isinstance(algorithm_parameters, AdamParameters):
             # Use the MF solver with Adam algorithm
-            return self._solve_adam(
+            mu, mu_tilde, sigma, mu_sample, sigma_sample, solve_time, S = self._solve_adam(
                 instance,
                 algorithm_parameters.to_dict(),
                 post_processor,
@@ -844,3 +846,64 @@ class MFSolver(CCVMSolver):
             raise ValueError(
                 f"Solver option type {type(algorithm_parameters)} is not supported."
             )
+            
+        # Run the post processor on the results, if specified
+        if post_processor:
+            post_processor_object = PostProcessorFactory.create_postprocessor(
+                post_processor
+            )
+
+            problem_variables = post_processor_object.postprocess(
+                self.change_variables(mu_tilde, S),
+                self.q_matrix,
+                self.v_vector,
+                device=self.device,
+            )
+            pp_time = post_processor_object.pp_time
+        else:
+            problem_variables = self.change_variables(mu_tilde, S)
+            pp_time = 0.0
+
+        objval = instance.compute_energy(problem_variables)
+
+        if evolution_step_size:
+            # Write samples to file
+            # Overwrite file if it exists
+            open(evolution_file, "w")
+
+            # Get the indices of the best objective values over the sampled iterations
+            # to use to get and save the best sampled values of mu and sigma
+            batch_index = torch.argmax(-objval)
+            with open(evolution_file, "a") as evolution_file_obj:
+                self._append_samples_to_file(
+                    mu_sample=mu_sample[batch_index],
+                    sigma_sample=sigma_sample[batch_index],
+                    evolution_file_object=evolution_file_obj,
+                )
+
+        solution = Solution(
+            problem_size=instance.problem_size,
+            batch_size=self.batch_size,
+            instance_name=instance.name,
+            iterations=self.parameter_key[instance.problem_size]["iterations"],
+            objective_values=objval,
+            solve_time=solve_time,
+            pp_time=pp_time,
+            optimal_value=instance.optimal_sol,
+            best_value=instance.best_sol,
+            num_frac_values=instance.num_frac_values,
+            solution_vector=instance.solution_vector,
+            variables={
+                "problem_variables": problem_variables,
+                "mu": mu,
+                "sigma": sigma,
+            },
+            device=self.device,
+        )
+
+        # Add evolution filename to solution if it was generated
+        if evolution_step_size:
+            solution.evolution_file = evolution_file
+
+        return solution
+

--- a/ccvm_simulators/solvers/mf_solver.py
+++ b/ccvm_simulators/solvers/mf_solver.py
@@ -291,7 +291,10 @@ class MFSolver(CCVMSolver):
                 the problem instance name.
 
         Returns:
-            solution (Solution): The solution to the problem instance.
+            mu, mu_tilde, sigma (tensor): random variables 
+            mu_sample, sigma_sample (tensor): random sample [needs attention] 
+            solve_time (float): Elapsed time 
+            S (float): Saturation bound
         """
         # If the instance and the solver don't specify the same device type, raise an
         # error
@@ -461,7 +464,10 @@ class MFSolver(CCVMSolver):
                 the problem instance name.
 
         Returns:
-            solution (Solution): The solution to the problem instance.
+            mu, mu_tilde, sigma (tensor): random variables 
+            mu_sample, sigma_sample (tensor): random sample [needs attention] 
+            solve_time (float): Elapsed time 
+            S (float): Saturation bound
         """
         # If the instance and the solver don't specify the same device type, raise an
         # error

--- a/ccvm_simulators/solvers/mf_solver.py
+++ b/ccvm_simulators/solvers/mf_solver.py
@@ -289,7 +289,7 @@ class MFSolver(CCVMSolver):
 
         Returns:
             mu, mu_tilde, sigma (tensor): random variables 
-            mu_sample, sigma_sample (tensor): random sample [needs attention] 
+            mu_sample, sigma_sample (tensor): variables for random samples 
             solve_time (float): Elapsed time 
             S (float): Saturation bound
         """
@@ -459,7 +459,7 @@ class MFSolver(CCVMSolver):
 
         Returns:
             mu, mu_tilde, sigma (tensor): random variables 
-            mu_sample, sigma_sample (tensor): random sample [needs attention] 
+            mu_sample, sigma_sample (tensor): variables for random samples 
             solve_time (float): Elapsed time 
             S (float): Saturation bound
         """

--- a/ccvm_simulators/solvers/mf_solver.py
+++ b/ccvm_simulators/solvers/mf_solver.py
@@ -335,8 +335,8 @@ class MFSolver(CCVMSolver):
         # Start timing the solve process
         solve_time_start = time.time()
 
-        mu_sample = None # Make it global variable
-        sigma_sample = None # Make it global variable
+        mu_sample = None 
+        sigma_sample = None 
         if evolution_step_size:
             # Check that the value is valid
             if evolution_step_size < 1:
@@ -505,8 +505,8 @@ class MFSolver(CCVMSolver):
         # Start timing the solve process
         solve_time_start = time.time()
 
-        mu_sample = None # Make it global variable
-        sigma_sample = None # Make it global variable
+        mu_sample = None 
+        sigma_sample = None 
         if evolution_step_size:
             # Check that the value is valid
             if evolution_step_size < 1:

--- a/ccvm_simulators/solvers/mf_solver.py
+++ b/ccvm_simulators/solvers/mf_solver.py
@@ -427,65 +427,6 @@ class MFSolver(CCVMSolver):
         
         return mu, mu_tilde, sigma, mu_sample, sigma_sample, solve_time, S 
 
-        # # Run the post processor on the results, if specified
-        # if post_processor:
-        #     post_processor_object = PostProcessorFactory.create_postprocessor(
-        #         post_processor
-        #     )
-        #
-        #     problem_variables = post_processor_object.postprocess(
-        #         self.change_variables(mu_tilde, S),
-        #         self.q_matrix,
-        #         self.v_vector,
-        #         device=device,
-        #     )
-        #     pp_time = post_processor_object.pp_time
-        # else:
-        #     problem_variables = self.change_variables(mu_tilde, S)
-        #     pp_time = 0.0
-        #
-        # objval = instance.compute_energy(problem_variables)
-        #
-        # if evolution_step_size:
-        #     # Write samples to file
-        #     # Overwrite file if it exists
-        #     open(evolution_file, "w")
-        #
-        #     # Get the indices of the best objective values over the sampled iterations
-        #     # to use to get and save the best sampled values of mu and sigma
-        #     batch_index = torch.argmax(-objval)
-        #     with open(evolution_file, "a") as evolution_file_obj:
-        #         self._append_samples_to_file(
-        #             mu_sample=mu_sample[batch_index],
-        #             sigma_sample=sigma_sample[batch_index],
-        #             evolution_file_object=evolution_file_obj,
-        #         )
-        #
-        # solution = Solution(
-        #     problem_size=problem_size,
-        #     batch_size=batch_size,
-        #     instance_name=instance.name,
-        #     iterations=iterations,
-        #     objective_values=objval,
-        #     solve_time=solve_time,
-        #     pp_time=pp_time,
-        #     optimal_value=instance.optimal_sol,
-        #     best_value=instance.best_sol,
-        #     num_frac_values=instance.num_frac_values,
-        #     solution_vector=instance.solution_vector,
-        #     variables={
-        #         "problem_variables": problem_variables,
-        #         "mu": mu,
-        #         "sigma": sigma,
-        #     },
-        #     device=device,
-        # )
-        #
-        # # Add evolution filename to solution if it was generated
-        # if evolution_step_size:
-        #     solution.evolution_file = evolution_file
-        #
-        # return solution
 
     def _solve_adam(
         self,
@@ -723,65 +664,6 @@ class MFSolver(CCVMSolver):
 
         return mu, mu_tilde, sigma, mu_sample, sigma_sample, solve_time, S
     
-        # # Run the post processor on the results, if specified
-        # if post_processor:
-        #     post_processor_object = PostProcessorFactory.create_postprocessor(
-        #         post_processor
-        #     )
-        #
-        #     problem_variables = post_processor_object.postprocess(
-        #         self.change_variables(mu_tilde, S),
-        #         self.q_matrix,
-        #         self.v_vector,
-        #         device=device,
-        #     )
-        #     pp_time = post_processor_object.pp_time
-        # else:
-        #     problem_variables = self.change_variables(mu_tilde, S)
-        #     pp_time = 0.0
-        #
-        # objval = instance.compute_energy(problem_variables)
-        #
-        # if evolution_step_size:
-        #     # Write samples to file
-        #     # Overwrite file if it exists
-        #     open(evolution_file, "w")
-        #
-        #     # Get the indices of the best objective values over the sampled iterations
-        #     # to use to get and save the best sampled values of mu and sigma
-        #     batch_index = torch.argmax(-objval)
-        #     with open(evolution_file, "a") as evolution_file_obj:
-        #         self._append_samples_to_file(
-        #             mu_sample=mu_sample[batch_index],
-        #             sigma_sample=sigma_sample[batch_index],
-        #             evolution_file_object=evolution_file_obj,
-        #         )
-        #
-        # solution = Solution(
-        #     problem_size=problem_size,
-        #     batch_size=batch_size,
-        #     instance_name=instance.name,
-        #     iterations=iterations,
-        #     objective_values=objval,
-        #     solve_time=solve_time,
-        #     pp_time=pp_time,
-        #     optimal_value=instance.optimal_sol,
-        #     best_value=instance.best_sol,
-        #     num_frac_values=instance.num_frac_values,
-        #     solution_vector=instance.solution_vector,
-        #     variables={
-        #         "problem_variables": problem_variables,
-        #         "mu": mu,
-        #         "sigma": sigma,
-        #     },
-        #     device=device,
-        # )
-        #
-        # # Add evolution filename to solution if it was generated
-        # if evolution_step_size:
-        #     solution.evolution_file = evolution_file
-        #
-        # return solution
 
     def __call__(
         self,

--- a/ccvm_simulators/tests/test_mf_solver.py
+++ b/ccvm_simulators/tests/test_mf_solver.py
@@ -252,7 +252,8 @@ class TestMFSolver(TestCase):
         self.mf_solver.change_variables = self.mock_change_variables
         self.mf_solver.calculate_grads = self.mock_calculate_grads
 
-        solution = self.mf_solver._solve(instance)
+        # solution = self.mf_solver._solve(instance)
+        solution = self.mf_solver(instance)
 
         # Check that the solution is correct
         assert solution.problem_size == instance.problem_size

--- a/ccvm_simulators/tests/test_mf_solver.py
+++ b/ccvm_simulators/tests/test_mf_solver.py
@@ -251,8 +251,7 @@ class TestMFSolver(TestCase):
         self.mf_solver.fit_to_constraints = self.mock_fit_to_constraints
         self.mf_solver.change_variables = self.mock_change_variables
         self.mf_solver.calculate_grads = self.mock_calculate_grads
-
-        # solution = self.mf_solver._solve(instance)
+        
         solution = self.mf_solver(instance)
 
         # Check that the solution is correct

--- a/examples/ccvm_boxqp_dl.py
+++ b/examples/ccvm_boxqp_dl.py
@@ -30,13 +30,12 @@ if __name__ == "__main__":
 
         # Solve the problem using the Adam algorithm
         adam_parameters = AdamParameters(
-            alpha=0.001, beta1=0.9, beta2=0.999, add_assign=False
+            alpha=0.001, beta1=0.9, beta2= 1.0, #0.999, add_assign=False
         )
 
         solution = solver(
             instance=boxqp_instance,
-            post_processor=None,
-            algorithm_parameters=adam_parameters,  # Set to None to use the original DL algorithm
+            post_processor=None,  algorithm_parameters=adam_parameters,  # Set to None to use the original DL algorithm
         )
 
         print(solution)

--- a/examples/ccvm_boxqp_dl.py
+++ b/examples/ccvm_boxqp_dl.py
@@ -36,7 +36,8 @@ if __name__ == "__main__":
 
         solution = solver(
             instance=boxqp_instance,
-            post_processor=None, # algorithm_parameters=adam_parameters,  # Set to None to use the original DL algorithm
+            post_processor=None, 
+            # algorithm_parameters=adam_parameters,  # Set to None to use the original DL algorithm
         )
 
         print(solution)

--- a/examples/ccvm_boxqp_dl.py
+++ b/examples/ccvm_boxqp_dl.py
@@ -30,12 +30,13 @@ if __name__ == "__main__":
 
         # Solve the problem using the Adam algorithm
         adam_parameters = AdamParameters(
-            alpha=0.001, beta1=0.9, beta2= 1.0, #0.999, add_assign=False
+            alpha=0.001, beta1=0.9, beta2=0.999, # 1.0, # 
+            add_assign=False
         )
 
         solution = solver(
             instance=boxqp_instance,
-            post_processor=None,  algorithm_parameters=adam_parameters,  # Set to None to use the original DL algorithm
+            post_processor=None, # algorithm_parameters=adam_parameters,  # Set to None to use the original DL algorithm
         )
 
         print(solution)

--- a/examples/ccvm_boxqp_mf.py
+++ b/examples/ccvm_boxqp_mf.py
@@ -37,13 +37,13 @@ if __name__ == "__main__":
 
         # Solve the problem using the Adam algorithm
         adam_parameters = AdamParameters(
-            alpha=0.001, beta1=0.9, beta2=0.999, add_assign=False
+            alpha=0.001, beta1=0.9, beta2=0.999, # 1.0, #   
+            add_assign=False
         )
 
         solution = solver(
             instance=boxqp_instance,
-            post_processor=None,
-            algorithm_parameters=adam_parameters,  # Set to None to use the original MF algorithm
+            post_processor=None, # algorithm_parameters=adam_parameters,  # Set to None to use the original MF algorithm
         )
 
         print(solution)

--- a/examples/ccvm_boxqp_mf.py
+++ b/examples/ccvm_boxqp_mf.py
@@ -43,7 +43,8 @@ if __name__ == "__main__":
 
         solution = solver(
             instance=boxqp_instance,
-            post_processor=None, # algorithm_parameters=adam_parameters,  # Set to None to use the original MF algorithm
+            post_processor=None, 
+            # algorithm_parameters=adam_parameters,  # Set to None to use the original MF algorithm
         )
 
         print(solution)

--- a/examples/ccvm_boxqp_mf.py
+++ b/examples/ccvm_boxqp_mf.py
@@ -37,7 +37,7 @@ if __name__ == "__main__":
 
         # Solve the problem using the Adam algorithm
         adam_parameters = AdamParameters(
-            alpha=0.001, beta1=0.9, beta2=0.999, # 1.0, #   
+            alpha=0.001, beta1=0.9, beta2= 1.0, #0.999, #   
             add_assign=False
         )
 

--- a/examples/langevin_boxqp.py
+++ b/examples/langevin_boxqp.py
@@ -35,12 +35,12 @@ if __name__ == "__main__":
 
         # Solve the problem using the Adam algorithm
         adam_parameters = AdamParameters(
-            alpha=0.001, beta1=0.9, beta2=0.999, add_assign=False
+            alpha=0.001, beta1=0.9, beta2=0.999, 
+            add_assign=False
         )
         solution = solver(
             instance=boxqp_instance,
-            post_processor=None,
-            algorithm_parameters=adam_parameters,  # Set to None to use the original Langevin algorithm
+            post_processor=None, # algorithm_parameters=adam_parameters,  # Set to None to use the original Langevin algorithm
         )
 
         print(solution)

--- a/examples/langevin_boxqp.py
+++ b/examples/langevin_boxqp.py
@@ -40,7 +40,7 @@ if __name__ == "__main__":
         )
         solution = solver(
             instance=boxqp_instance,
-            post_processor=None, # algorithm_parameters=adam_parameters,  # Set to None to use the original Langevin algorithm
+            post_processor=None,  algorithm_parameters=adam_parameters,  # Set to None to use the original Langevin algorithm
         )
 
         print(solution)

--- a/examples/langevin_boxqp.py
+++ b/examples/langevin_boxqp.py
@@ -35,12 +35,12 @@ if __name__ == "__main__":
 
         # Solve the problem using the Adam algorithm
         adam_parameters = AdamParameters(
-            alpha=0.001, beta1=0.9, beta2=0.999, 
+            alpha=0.001, beta1=0.9, beta2=1.0, #0.999, 
             add_assign=False
         )
         solution = solver(
             instance=boxqp_instance,
-            post_processor=None,  algorithm_parameters=adam_parameters,  # Set to None to use the original Langevin algorithm
+            post_processor=None,  # algorithm_parameters=adam_parameters,  # Set to None to use the original Langevin algorithm
         )
 
         print(solution)

--- a/examples/langevin_boxqp.py
+++ b/examples/langevin_boxqp.py
@@ -40,7 +40,8 @@ if __name__ == "__main__":
         )
         solution = solver(
             instance=boxqp_instance,
-            post_processor=None,  # algorithm_parameters=adam_parameters,  # Set to None to use the original Langevin algorithm
+            post_processor=None,  
+            # algorithm_parameters=adam_parameters,  # Set to None to use the original Langevin algorithm
         )
 
         print(solution)


### PR DESCRIPTION
Please see the [contributing guidelines](https://github.com/ccvm/master/CONTRIBUTING.md) for how to create and submit a high-quality PR for this repo.

### Description

> In `LangevinSolver`, `DLSolver`, and `MFSolver` classes, `solution` update is handled at the end of `_solve()` and `_solve_adam()` methods before returning the outcome to `__call__()` method. Such a redundancy must be avoided for an efficient code management including maintenance and readability. 

### References

Closes #123 

### Checklist

- [x]  All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not main
- [x] Issue #123 is addressed in this PR
- [x] `Changelog` is update
- [x] Sample scripts in `ccvm/examples/` were executed for different options