### PR TITLE
Updating the saturation parameter treatment in `pumped_langevin_solver`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,12 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Breaking Changes
 - Removed the `TrustConst` post-processor from the codebase due to non-usage. This
   change aims to streamline the code and eliminate unnecessary components.
-- Added a saturation parameter `S` as the input to the `langevin_solver` and removed this
-parameter from the `__init__` function. `S` now has to be provided by the user using
-`solver.parameter_key`.
-- Added a saturation parameter `S` as the input to the `pumped_langevin_solver` and removed this
-parameter from the `__init__` function. `S` now has to be provided by the user using
-`solver.parameter_key`.
+- Added a saturation parameter `S` as the input to the `langevin_solver` and
+`pumped_langevin_solver` and removed this parameter from the solvers `__init__` functions.
+`S` now has to be provided by the user using `solver.parameter_key`.
 - Renamed the `MetadataList` class to `Metadata`, transforming metadata from a list
   to a dictionary object. The metadata class now requires a device parameter
   during initialization.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added a saturation parameter `S` as the input to the `langevin_solver` and removed this
 parameter from the `__init__` function. `S` now has to be provided by the user using
 `solver.parameter_key`.
+- Added a saturation parameter `S` as the input to the `pumped_langevin_solver` and removed this
+parameter from the `__init__` function. `S` now has to be provided by the user using
+`solver.parameter_key`.
 - Renamed the `MetadataList` class to `Metadata`, transforming metadata from a list
   to a dictionary object. The metadata class now requires a device parameter
   during initialization.

--- a/ccvm_simulators/solvers/pumped_langevin_solver.py
+++ b/ccvm_simulators/solvers/pumped_langevin_solver.py
@@ -20,7 +20,6 @@ class PumpedLangevinSolver(CCVMSolver):
         device,
         problem_category="boxqp",
         batch_size=1000,
-        S=1,
     ):
         """
         Args:
@@ -39,7 +38,6 @@ class PumpedLangevinSolver(CCVMSolver):
         """
         super().__init__(device)
         self.batch_size = batch_size
-        self.S = S
         self._scaling_multiplier = LANGEVIN_SCALING_MULTIPLIER
         # Use the method selector to choose the problem-specific methods to use
         self._method_selector(problem_category)
@@ -76,7 +74,7 @@ class PumpedLangevinSolver(CCVMSolver):
     @parameter_key.setter
     def parameter_key(self, parameters):
         expected_pl_parameter_key_set = set(
-            ["pump", "dt", "iterations", "sigma", "feedback_scale"]
+            ["pump", "dt", "S", "iterations", "sigma", "feedback_scale"]
         )
         parameter_key_list = parameters.values()
         # Iterate over the parameters for each given problem size
@@ -480,7 +478,6 @@ class PumpedLangevinSolver(CCVMSolver):
         self.v_vector = instance.v_vector
 
         # Get solver setup variables
-        S = self.S
         batch_size = self.batch_size
         device = self.device
 
@@ -488,6 +485,7 @@ class PumpedLangevinSolver(CCVMSolver):
         try:
             pump = self.parameter_key[problem_size]["pump"]
             dt = self.parameter_key[problem_size]["dt"]
+            S = self.parameter_key[problem_size]["S"]
             iterations = self.parameter_key[problem_size]["iterations"]
             sigma = self.parameter_key[problem_size]["sigma"]
             feedback_scale = self.parameter_key[problem_size]["feedback_scale"]

--- a/examples/pumped_langevin_boxqp.py
+++ b/examples/pumped_langevin_boxqp.py
@@ -10,15 +10,14 @@ TEST_INSTANCES_PATH = f"./benchmarking_instances/{TEST_INSTANCES_DIR_NAME}/"
 if __name__ == "__main__":
     # Initialize solver
     batch_size = 1000
-    solver = PumpedLangevinSolver(
-        device="cpu", batch_size=batch_size, S=0.5
-    )  # or "cuda"
+    solver = PumpedLangevinSolver(device="cpu", batch_size=batch_size)  # or "cuda"
 
     # Supply solver parameters for different problem sizes
     solver.parameter_key = {
         20: {
             "pump": 2.0,  # p0
             "dt": 0.002,
+            "S": 0.5,
             "iterations": 1500,
             "sigma": 0.5,
             "feedback_scale": 1.0,


### PR DESCRIPTION
### Description
To be consistent with the `langevin_solver` and `mf-ccvm` solver, I've changed the solver to receive the saturation parameter `S` as a parameter key instead of a parameter at the time of definition. 

### References
Closes #177 

### Testing
This can be tested by running the example file `pumped_langevin_boxqp.py` in the examples folder and obtaining good results. The value of the saturation parameter `S` can be changed when setting the `parameter_key` for further testing. 

- [ ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [x] I have added documentation for new/changed functionality in this PR
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not `main`