### PR TITLE
Add machine time calculation functions for cpu/gpu in CCVMSolver class

### DIFF
--- a/ccvm_simulators/ccvmplotlib/problem_metadata/boxqp_metadata.py
+++ b/ccvm_simulators/ccvmplotlib/problem_metadata/boxqp_metadata.py
@@ -115,7 +115,7 @@ class BoxQPMetadata(ProblemMetadata):
                     )
 
                     metric_value = metric_func(
-                        matching_df=matching_df, problem_size=problem_size
+                        dataframe=matching_df, problem_size=problem_size
                     )
 
                     success_prob = matching_df[percent_gap].values
@@ -130,9 +130,9 @@ class BoxQPMetadata(ProblemMetadata):
                         R99 = np.mean(R99_distribution)
 
                     mean_metric = metric_value * R99
-                    plotting_df.at[
-                        problem_size, (percent_gap, percentile)
-                    ] = mean_metric
+                    plotting_df.at[problem_size, (percent_gap, percentile)] = (
+                        mean_metric
+                    )
 
         return plotting_df
 
@@ -162,8 +162,8 @@ class BoxQPMetadata(ProblemMetadata):
                     )
                 )
 
-                plotting_df.at[
-                    problem_size, (percent_gap, "success_prob")
-                ] = mean_success_prob
+                plotting_df.at[problem_size, (percent_gap, "success_prob")] = (
+                    mean_success_prob
+                )
 
         return plotting_df

--- a/ccvm_simulators/solvers/ccvm_solver.py
+++ b/ccvm_simulators/solvers/ccvm_solver.py
@@ -169,6 +169,10 @@ class CCVMSolver(ABC):
                 f" Given category: {problem_category}"
             )
 
+    ################################
+    ### MACHINE ENERGY FUNCTIONS ###
+    ################################
+
     def _validate_machine_energy_dataframe_columns(self, dataframe):
         """Validates that the given dataframe contains the required columns when
         calculating optics machine energy on DL-CCVM and MF-CCVM solvers.
@@ -214,12 +218,12 @@ class CCVMSolver(ABC):
                     "The dictionary must contain the key 'cpu_power'"
                 )
 
-        def _cpu_machine_energy_callable(matching_df: DataFrame, problem_size: int):
+        def _cpu_machine_energy_callable(dataframe: DataFrame, problem_size: int):
             """Calculate the average energy consumption of the solver simulating on a
             cpu machine.
 
             Args:
-                matching_df (DataFrame): The necessary data to calculate the average
+                dataframe (DataFrame): The necessary data to calculate the average
                     energy.
                 problem_size (int): The size of the problem.
 
@@ -230,11 +234,11 @@ class CCVMSolver(ABC):
             Returns:
                 float: The average energy consumption of the solver.
             """
-            if "solve_time" not in matching_df.columns:
+            if "solve_time" not in dataframe.columns:
                 raise ValueError(
                     "The given dataframe does not contain the column 'solve_time'"
                 )
-            machine_time = np.mean(matching_df["solve_time"].values)
+            machine_time = np.mean(dataframe["solve_time"].values)
             machine_power = machine_parameters["cpu_power"][problem_size]
             machine_energy = machine_power * machine_time
             return machine_energy
@@ -266,12 +270,12 @@ class CCVMSolver(ABC):
                     "The dictionary must contain the key 'gpu_power'"
                 )
 
-        def _cuda_machine_energy_callable(matching_df: DataFrame, problem_size: int):
+        def _cuda_machine_energy_callable(dataframe: DataFrame, problem_size: int):
             """Calculate the average energy consumption of the solver simulating on a
             system equipped with CUDA-capable GPUs.
 
             Args:
-                matching_df (DataFrame): The necessary data to calculate the average
+                dataframe (DataFrame): The necessary data to calculate the average
                     energy.
                 problem_size (int): The size of the problem.
 
@@ -282,12 +286,12 @@ class CCVMSolver(ABC):
             Returns:
                 float: The average power consumption of the solver.
             """
-            if "solve_time" not in matching_df.columns:
+            if "solve_time" not in dataframe.columns:
                 raise ValueError(
                     "The given dataframe does not contain the column 'solve_time'"
                 )
 
-            machine_time = np.mean(matching_df["solve_time"].values)
+            machine_time = np.mean(dataframe["solve_time"].values)
             machine_power = machine_parameters["gpu_power"][problem_size]
             machine_energy = machine_power * machine_time
             return machine_energy
@@ -312,15 +316,21 @@ class CCVMSolver(ABC):
         solver_energy_methods = {
             "cpu": self._cpu_machine_energy,
             "gpu": self._cuda_machine_energy,
-            "dl-ccvm": self._optics_machine_energy
-            if self.__class__.__name__ == "DLSolver"
-            else None,
-            "mf-ccvm": self._optics_machine_energy
-            if self.__class__.__name__ == "MFSolver"
-            else None,
-            "fpga": self._fpga_machine_energy
-            if self.__class__.__name__ == "LangevinSolver"
-            else None,
+            "dl-ccvm": (
+                self._optics_machine_energy
+                if self.__class__.__name__ == "DLSolver"
+                else None
+            ),
+            "mf-ccvm": (
+                self._optics_machine_energy
+                if self.__class__.__name__ == "MFSolver"
+                else None
+            ),
+            "fpga": (
+                self._fpga_machine_energy
+                if self.__class__.__name__ == "LangevinSolver"
+                else None
+            ),
         }
 
         if machine not in solver_energy_methods:
@@ -338,3 +348,152 @@ class CCVMSolver(ABC):
             )
 
         return energy_method(machine_parameters)
+
+    ##############################
+    ### MACHINE TIME FUNCTIONS ###
+    ##############################
+
+    # TODO before merge: Check that this function gets used somewhere, then update or delete it
+    def _validate_machine_time_dataframe_columns(self, dataframe):
+        """Validates that the given dataframe contains the required columns when
+        calculating optics machine time on DL-CCVM and MF-CCVM solvers.
+
+        Args:
+            dataframe (DataFrame): The dataframe to validate.
+
+        Raises:
+            ValueError: If the given dataframe is missing any of the required columns.
+        """
+        required_columns = ["pp_time", "iterations"]
+
+        missing_columns = [
+            col for col in required_columns if col not in dataframe.columns
+        ]
+
+        if missing_columns:
+            raise ValueError(
+                f"The given dataframe is missing the following columns: {missing_columns}"
+            )
+
+    def _cpu_machine_time(self, **_):
+        """The wrapper function of calculating the average time taken by the solver during
+        the simulation when using a CPU machine.
+
+        Raises:
+            ValueError: when the given dataframe does not contain the required columns.
+
+        Returns:
+            Callable: A callable function that takes in a dataframe and problem size and
+                returns the average time taken by the solver.
+        """
+
+        # TODO before merge: change rpblen size to a **_
+        def _cpu_machine_time_callable(dataframe: DataFrame, problem_size: int):
+            """Calculate the average time taken by the solver during the simulation when
+            using a CPU machine.
+
+            Args:
+                dataframe (DataFrame): The necessary data to calculate the average
+                    time spent during the simulation.
+                problem_size (int): The size of the problem.
+
+            Raises:
+                ValueError: when the given dataframe does not contain the required
+                    columns.
+
+            Returns:
+                float: The average time taken by the solver during one simulation.
+            """
+            if "solve_time" not in dataframe.columns:
+                raise ValueError(
+                    "The given dataframe does not contain the column 'solve_time'"
+                )
+            machine_time = np.mean(dataframe["solve_time"].values)
+            return machine_time
+
+        return _cpu_machine_time_callable
+
+    def _cuda_machine_time(self, **_):
+        """The wrapper function of calculating the average time taken by the solver during
+        the simulation when using a system equipped with CUDA-capable GPUs.
+
+        Raises:
+            ValueError: when the given dataframe does not contain the required columns.
+
+        Returns:
+            Callable: A callable function that takes in a dataframe and problem size and
+                returns the average time taken by the solver.
+        """
+
+        # TODO before merge: change rpblen size to a kwarg
+        def _cuda_machine_time_callable(dataframe: DataFrame, problem_size: int):
+            """Calculate the average time taken by the solver during the simulation when
+            using a system equipped with CUDA-capable GPUs.
+
+            Args:
+                dataframe (DataFrame): The necessary data to calculate the average
+                    time spent during the simulation.
+                problem_size (int): The size of the problem.
+
+            Raises:
+                ValueError: when the given dataframe does not contain the required
+                    columns.
+
+            Returns:
+                float: The average time taken by the solver during one simulation.
+            """
+            if "solve_time" not in dataframe.columns:
+                raise ValueError(
+                    "The given dataframe does not contain the column 'solve_time'"
+                )
+            machine_time = np.mean(dataframe["solve_time"].values)
+            return machine_time
+
+        return _cuda_machine_time_callable
+
+    # TODO before merge: I think "during one simulation" might be a miswording, so I gotta check on that.
+    def machine_time(self, machine: str, machine_parameters: dict = None):
+        """Calculates the average time spent during the simulation by the specified hardware
+        for a given problem size.
+
+        Args:
+            machine (str): The type of machine for which to calculate the average time for
+                each simulation.
+            machine_parameters (dict): Parameters of the machine. Defaults to None.
+
+        Raises:
+            ValueError: If the given machine is not a valid machine type.
+            ValueError: If there is a mismatch between the solver and the machine type.
+        Returns:
+            Callable: A callable function that calculates the average time taken by the
+                solver during one simulation on the given machine type.
+        """
+        solver_time_methods = {
+            "cpu": self._cpu_machine_time,
+            "gpu": self._cuda_machine_time,
+            # "dl-ccvm": self._optics_machine_time
+            # if self.__class__.__name__ == "DLSolver"
+            # else None,
+            # "mf-ccvm": self._optics_machine_time
+            # if self.__class__.__name__ == "MFSolver"
+            # else None,
+            # "fpga": self._fpga_machine_time
+            # if self.__class__.__name__ == "LangevinSolver"
+            # else None,
+        }
+
+        if machine not in solver_time_methods:
+            raise ValueError(
+                f"The given machine type is not valid. "
+                f"The machine type must be one of {', '.join(solver_time_methods.keys())}"
+            )
+
+        time_method = solver_time_methods[machine]
+
+        if not time_method:
+            raise ValueError(
+                f"Mismatch between the solver and the machine type. "
+                f"Provided machine type: {machine}, solver type: {self.__class__.__name__}"
+            )
+
+        return time_method(machine_parameters=machine_parameters)

--- a/ccvm_simulators/solvers/ccvm_solver.py
+++ b/ccvm_simulators/solvers/ccvm_solver.py
@@ -353,7 +353,6 @@ class CCVMSolver(ABC):
     ### MACHINE TIME FUNCTIONS ###
     ##############################
 
-    # TODO before merge: Check that this function gets used somewhere, then update or delete it
     def _validate_machine_time_dataframe_columns(self, dataframe):
         """Validates that the given dataframe contains the required columns when
         calculating optics machine time on DL-CCVM and MF-CCVM solvers.
@@ -387,8 +386,7 @@ class CCVMSolver(ABC):
                 returns the average time taken by the solver.
         """
 
-        # TODO before merge: change rpblen size to a **_
-        def _cpu_machine_time_callable(dataframe: DataFrame, problem_size: int):
+        def _cpu_machine_time_callable(dataframe: DataFrame, **_):
             """Calculate the average time taken by the solver during the simulation when
             using a CPU machine.
 
@@ -402,7 +400,8 @@ class CCVMSolver(ABC):
                     columns.
 
             Returns:
-                float: The average time taken by the solver during one simulation.
+                float: The average time taken by the solver during simulation of a single
+                    instance.
             """
             if "solve_time" not in dataframe.columns:
                 raise ValueError(
@@ -425,8 +424,7 @@ class CCVMSolver(ABC):
                 returns the average time taken by the solver.
         """
 
-        # TODO before merge: change rpblen size to a kwarg
-        def _cuda_machine_time_callable(dataframe: DataFrame, problem_size: int):
+        def _cuda_machine_time_callable(dataframe: DataFrame, **_):
             """Calculate the average time taken by the solver during the simulation when
             using a system equipped with CUDA-capable GPUs.
 
@@ -440,7 +438,8 @@ class CCVMSolver(ABC):
                     columns.
 
             Returns:
-                float: The average time taken by the solver during one simulation.
+                float: The average time taken by the solver during simulation of a single
+                    instance.
             """
             if "solve_time" not in dataframe.columns:
                 raise ValueError(
@@ -451,14 +450,13 @@ class CCVMSolver(ABC):
 
         return _cuda_machine_time_callable
 
-    # TODO before merge: I think "during one simulation" might be a miswording, so I gotta check on that.
     def machine_time(self, machine: str, machine_parameters: dict = None):
         """Calculates the average time spent during the simulation by the specified hardware
         for a given problem size.
 
         Args:
             machine (str): The type of machine for which to calculate the average time for
-                each simulation.
+                simulating a single instance.
             machine_parameters (dict): Parameters of the machine. Defaults to None.
 
         Raises:
@@ -466,7 +464,7 @@ class CCVMSolver(ABC):
             ValueError: If there is a mismatch between the solver and the machine type.
         Returns:
             Callable: A callable function that calculates the average time taken by the
-                solver during one simulation on the given machine type.
+                solver during simulation of a single instance on the given machine type.
         """
         solver_time_methods = {
             "cpu": self._cpu_machine_time,

--- a/ccvm_simulators/tests/unit/ccvmplotlib/test_BoxQP_metadata.py
+++ b/ccvm_simulators/tests/unit/ccvmplotlib/test_BoxQP_metadata.py
@@ -24,14 +24,14 @@ class TestBoxQPMetadata(TestCase):
             "ccvm_simulators/tests/data/metadata/invalid_incorrect_field_metadata.json"
         )
 
-        def valid_machine_func(matching_df: pd.DataFrame, **_: any) -> float:
-            return np.mean(matching_df["solve_time"].values, dtype=float)
+        def valid_machine_func(dataframe: pd.DataFrame, **_: any) -> float:
+            return np.mean(dataframe["solve_time"].values, dtype=float)
 
-        def valid_energy_func(matching_df: pd.DataFrame, problem_size: int) -> float:
+        def valid_energy_func(dataframe: pd.DataFrame, problem_size: int) -> float:
             machine_parameters = {
                 "cpu_power": {20: 5.0, 30: 5.0, 40: 5.0, 50: 5.0, 60: 5.0, 70: 5.0}
             }
-            machine_time = np.mean(matching_df["solve_time"].values)
+            machine_time = np.mean(dataframe["solve_time"].values)
             machine_power = machine_parameters["cpu_power"][problem_size]
             machine_energy = machine_power * machine_time
             return machine_energy

--- a/ccvm_simulators/tests/unit/solvers/test_ccvm_solver.py
+++ b/ccvm_simulators/tests/unit/solvers/test_ccvm_solver.py
@@ -316,11 +316,6 @@ class TestCCVMSolverMachineTime(TestCase):
         with self.assertRaises(ValueError):
             self.dl_solver.machine_time("invalid_machine_type")
 
-    # def test_machine_time_mismatch_solver_machine_type(self):
-    #     """Test if ValueError is raised when machine type is not compatible with the solver."""
-    #     with self.assertRaises(ValueError):
-    #         self.langevin_solver.machine_time(MachineType.DL_CCVM.value)
-
     def test_machine_time_dl_solver_with_cpu_machine(self):
         """Test if machine_time works correctly when machine type is cpu for
         DLSolver."""

--- a/examples/ccvm_boxqp_plot.py
+++ b/examples/ccvm_boxqp_plot.py
@@ -29,8 +29,20 @@ if __name__ == "__main__":
 
     # Supply solver parameters for different problem sizes
     solver.parameter_key = {
-        10: {"pump": 1.0, "dt": 0.001, "iterations": 10000, "noise_ratio": 15},
-        20: {"pump": 2.0, "dt": 0.005, "iterations": 15000, "noise_ratio": 10},
+        10: {
+            "pump": 1.0,
+            "dt": 0.001,
+            "iterations": 10000,
+            "noise_ratio": 15,
+            "feedback_scale": 95,
+        },
+        20: {
+            "pump": 2.0,
+            "dt": 0.005,
+            "iterations": 15000,
+            "noise_ratio": 10,
+            "feedback_scale": 100,
+        },
     }
 
     metadata_obj = Metadata(device=solver.device)
@@ -63,15 +75,15 @@ if __name__ == "__main__":
         os.makedirs(PLOT_OUTPUT_DIR)
         print("Plot folder doesn't exist yet. Creating: ", PLOT_OUTPUT_DIR)
 
-    # Plotting TTS
-    # Customize machine time calculating function
-    def cpu_machine_func(matching_df: pd.DataFrame, **_: any) -> float:
-        return np.mean(matching_df["solve_time"].values)
+    # # Plotting TTS
+    # # Customize machine time calculating function
+    # def cpu_machine_func(matching_df: pd.DataFrame, **_: any) -> float:
+    #     return np.mean(matching_df["solve_time"].values)
 
     tts_plot_fig, tts_plot_ax = ccvmplotlib.plot_TTS(
         metadata_filepath=metadata_filepath,
         problem="BoxQP",
-        machine_time_func=cpu_machine_func,
+        machine_time_func=solver.machine_time(machine="cpu"),
     )
 
     ccvmplotlib.apply_default_tts_styling(

--- a/examples/ccvm_boxqp_plot.py
+++ b/examples/ccvm_boxqp_plot.py
@@ -30,14 +30,14 @@ if __name__ == "__main__":
     # Supply solver parameters for different problem sizes
     solver.parameter_key = {
         10: {
-            "pump": 1.0,
+            "pump": 8.0,
             "dt": 0.001,
             "iterations": 10000,
             "noise_ratio": 15,
             "feedback_scale": 95,
         },
         20: {
-            "pump": 2.0,
+            "pump": 8.0,
             "dt": 0.005,
             "iterations": 15000,
             "noise_ratio": 10,

--- a/examples/ccvm_boxqp_plot.py
+++ b/examples/ccvm_boxqp_plot.py
@@ -75,11 +75,6 @@ if __name__ == "__main__":
         os.makedirs(PLOT_OUTPUT_DIR)
         print("Plot folder doesn't exist yet. Creating: ", PLOT_OUTPUT_DIR)
 
-    # # Plotting TTS
-    # # Customize machine time calculating function
-    # def cpu_machine_func(matching_df: pd.DataFrame, **_: any) -> float:
-    #     return np.mean(matching_df["solve_time"].values)
-
     tts_plot_fig, tts_plot_ax = ccvmplotlib.plot_TTS(
         metadata_filepath=metadata_filepath,
         problem="BoxQP",


### PR DESCRIPTION
This commit adds a machine_time function to the solvers so that a user can choose to pass one of these default metrics calculations to the plotter to calculate the metrics instead of having to write their own calculation implementation.

Closes #158

This commit just includes the CPU and GPU calculations; future commits (other PRs) will incorporate the optic machine calculations

### Testing

You can verify this feature by:
- running the new unit tests
- customizing the solver type and/or the `machine` parameter of `machine_time()` in the `examples/ccvm_boxqp_plot.py` file and then running it

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not `main`