### PR TITLE
Add solution bounds to the box constraints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ for a single calculation of an instance intead of the time to solve the full bat
 - Added `PumpedLangevinSolver`, which is an extension of `LangevinSolver` to simulate pumped Langevin dynamics with a demo script in the examples directory.
 - Implemented a simple gradient descent post-processing step, as described in the paper, similar to Langevin dynamics but without noise; uses the Euler method with box constraint imposition at each iteration.
 - Added a scaling coefficient for the feedback term in `dl-ccvm` as an input to the solver
+- Added `solution_bounds` to the BoxQP `ProblemInstance` class to allow users to specify the lower and upper bounds of the solution vector.
 
 ### Changed
 - Streamlined README by relocating and optimizing architecture diagrams.

--- a/ccvm_simulators/problem_classes/boxqp/problem_instance.py
+++ b/ccvm_simulators/problem_classes/boxqp/problem_instance.py
@@ -27,6 +27,7 @@ class ProblemInstance:
         file_path=None,
         file_delimiter="\t",
         name=None,
+        solution_bounds=(0.0, 1.0),
     ):
         """Problem instance constructor.
 
@@ -41,6 +42,9 @@ class ProblemInstance:
                 file. Defaults to "\t".
             name (str, optional): The name of the problem instance. If not
                 given, defaults to the file name when an instance is loaded.
+            solution_bounds (tuple(float), optional): The minimum and maximum value allowed
+                (inclusively) in the solution vector. The first value is the minimum, the
+                second is the maximum. Defaults to (0.0,1.0).
 
         Attributes:
             problem_size (int): instance size. Defaults to None.
@@ -87,6 +91,27 @@ class ProblemInstance:
                 file_delimiter=file_delimiter,
             )
         self.problem_category = "boxqp"
+        self.solution_bounds = solution_bounds
+
+
+    @property
+    def solution_bounds(self):
+        """ The minimum and maximum value allowed (inclusively) in the solution vector.
+        The first value is the minimum, the second is the maximum.
+
+        Returns:
+            tuple(float): The minimum and maximum solution bounds.
+        """
+        return self._solution_bounds
+
+    @solution_bounds.setter
+    def solution_bounds(self, bounds):
+        if len(bounds) != 2:
+            raise ValueError("solution_bounds must be a tuple of size 2, containing the minimum and maximum bounds (inclusive)")
+        elif bounds[0] >= bounds[1]:
+            raise ValueError("Minimum solution bound must be less than maximum solution bound")
+        else:
+            self._solution_bounds = bounds
 
     def load_instance(
         self, device="cpu", instance_type="tuning", file_path=None, file_delimiter=None

--- a/ccvm_simulators/solvers/dl_solver.py
+++ b/ccvm_simulators/solvers/dl_solver.py
@@ -200,8 +200,17 @@ class DLSolver(CCVMSolver):
         )
         c_grad_3 = self.v_vector * (upper_limit - lower_limit) / (2 * S)
 
-        s_grad_1 = 0.25 * torch.einsum("bi,ij -> bj", s / S + 1, self.q_matrix) / S
-        s_grad_3 = self.v_vector / 2 / S
+        s_grad_1 = (
+            0.25
+            * torch.einsum(
+                "bi,ij -> bj",
+                s * (upper_limit - lower_limit) / S + (upper_limit + lower_limit),
+                self.q_matrix,
+            )
+            * (upper_limit - lower_limit)
+            / S
+        )
+        s_grad_3 = self.v_vector * (upper_limit - lower_limit) / (2 * S)
 
         c_grads = -c_grad_1 - c_grad_3
         s_grads = -s_grad_1 - s_grad_3

--- a/ccvm_simulators/solvers/dl_solver.py
+++ b/ccvm_simulators/solvers/dl_solver.py
@@ -184,7 +184,9 @@ class DLSolver(CCVMSolver):
         Returns:
             torch.Tensor: The changed variables.
         """
-        return 0.5 * (problem_variables / S + 1)
+        return 0.5 * problem_variables / S * (
+            self.solution_bounds[1] - self.solution_bounds[0]
+        ) + 0.5 * (self.solution_bounds[1] + self.solution_bounds[0])
 
     def _fit_to_constraints_boxqp(self, c, lower_clamp, upper_clamp):
         """Clamps the values of c to be within the box constraints
@@ -704,6 +706,7 @@ class DLSolver(CCVMSolver):
         problem_size = instance.problem_size
         self.q_matrix = instance.q_matrix
         self.v_vector = instance.v_vector
+        self.solution_bounds = instance.solution_bounds
 
         # Get solver setup variables
         S = self.S

--- a/ccvm_simulators/solvers/dl_solver.py
+++ b/ccvm_simulators/solvers/dl_solver.py
@@ -458,7 +458,13 @@ class DLSolver(CCVMSolver):
             noise_ratio_i = (noise_ratio - 1) * np.exp(-(i + 1) / iterations * 3) + 1
 
             c_drift, s_drift = self.calculate_drift(
-                c, s, pump, pump_rate, feedback_scale
+                c,
+                s,
+                pump,
+                pump_rate,
+                feedback_scale,
+                self.solution_bounds[0],
+                self.solution_bounds[1],
             )
             wiener_increment_c = (
                 wiener_dist_c.sample((problem_size,)).transpose(0, 1)

--- a/ccvm_simulators/solvers/dl_solver.py
+++ b/ccvm_simulators/solvers/dl_solver.py
@@ -153,16 +153,25 @@ class DLSolver(CCVMSolver):
         c_grad_2 = torch.einsum("cj,cj -> cj", -1 + (pump * rate) - c_pow - s_pow, c)
         c_grad_3 = self.v_vector * (upper_limit - lower_limit) / (2 * S)
 
-        s_grad_1 = 0.25 * torch.einsum("bi,ij -> bj", s / S + 1, self.q_matrix) / S
+        s_grad_1 = (
+            0.25
+            * torch.einsum(
+                "bi,ij -> bj",
+                s * (upper_limit - lower_limit) / S + (upper_limit + lower_limit),
+                self.q_matrix,
+            )
+            * (upper_limit - lower_limit)
+            / S
+        )
         s_grad_2 = torch.einsum("cj,cj -> cj", -1 - (pump * rate) - c_pow - s_pow, s)
-        s_grad_3 = self.v_vector / 2 / S
+        s_grad_3 = self.v_vector * (upper_limit - lower_limit) / (2 * S)
 
         feedback_scale_dynamic = feedback_scale * (0.5 + rate)
         c_drift = -feedback_scale_dynamic * (c_grad_1 + c_grad_3) + c_grad_2
         s_drift = -feedback_scale_dynamic * (s_grad_1 + s_grad_3) + s_grad_2
         return c_drift, s_drift
 
-    def _calculate_grads_boxqp(self, c, s, S=1):
+    def _calculate_grads_boxqp(self, c, s, lower_limit=0, upper_limit=1, S=1):
         """We treat the SDE that simulates the CIM of NTT as gradient
         calculation. Original SDE considers only quadratic part of the objective
         function. Therefore, we need to modify and add linear part of the QP to
@@ -171,14 +180,25 @@ class DLSolver(CCVMSolver):
         Args:
             c (torch.Tensor): In-phase amplitudes of the solver
             s (torch.Tensor): Quadrature amplitudes of the solver
+            lower_limit (float): The lower bound of the box constraints. Defaults to 0.
+            upper_limit (float): The upper bound of the box constraints. Defaults to 1.
             S (float): The saturation value of the amplitudes. Defaults to 1.
 
         Returns:
             tuple: The calculated change in the variable amplitudes.
         """
 
-        c_grad_1 = 0.25 * torch.einsum("bi,ij -> bj", c / S + 1, self.q_matrix) / S
-        c_grad_3 = self.v_vector / 2 / S
+        c_grad_1 = (
+            0.25
+            * torch.einsum(
+                "bi,ij -> bj",
+                c * (upper_limit - lower_limit) / S + (upper_limit + lower_limit),
+                self.q_matrix,
+            )
+            * (upper_limit - lower_limit)
+            / S
+        )
+        c_grad_3 = self.v_vector * (upper_limit - lower_limit) / (2 * S)
 
         s_grad_1 = 0.25 * torch.einsum("bi,ij -> bj", s / S + 1, self.q_matrix) / S
         s_grad_3 = self.v_vector / 2 / S
@@ -597,7 +617,9 @@ class DLSolver(CCVMSolver):
             noise_ratio_i = (noise_ratio - 1) * np.exp(-(i + 1) / iterations * 3) + 1
 
             # Calculate gradient
-            c_grads, s_grads = self.calculate_grads(c, s, S)
+            c_grads, s_grads = self.calculate_grads(
+                c, s, self.solution_bounds[0], self.solution_bounds[1], S
+            )
 
             # Update biased first moment estimate
             m_c = beta1 * m_c + (1.0 - beta1) * c_grads

--- a/ccvm_simulators/solvers/langevin_solver.py
+++ b/ccvm_simulators/solvers/langevin_solver.py
@@ -163,7 +163,9 @@ class LangevinSolver(CCVMSolver):
         Returns:
             torch.Tensor: The changed variables.
         """
-        return 0.5 * (problem_variables / S + 1)
+        return 0.5 * problem_variables / S * (
+            self.solution_bounds[1] - self.solution_bounds[0]
+        ) + 0.5 * (self.solution_bounds[1] + self.solution_bounds[0])
 
     def _fit_to_constraints_boxqp(self, c, lower_clamp, upper_clamp):
         """Clamps the values of c to be within the box constraints
@@ -522,6 +524,7 @@ class LangevinSolver(CCVMSolver):
         problem_size = instance.problem_size
         self.q_matrix = instance.q_matrix
         self.v_vector = instance.v_vector
+        self.solution_bounds = instance.solution_bounds
 
         # Get solver setup variables
         batch_size = self.batch_size

--- a/ccvm_simulators/solvers/langevin_solver.py
+++ b/ccvm_simulators/solvers/langevin_solver.py
@@ -153,19 +153,23 @@ class LangevinSolver(CCVMSolver):
 
         return c_grads
 
-    def _change_variables_boxqp(self, problem_variables, S=1):
+    def _change_variables_boxqp(
+        self, problem_variables, lower_limit=0, upper_limit=1, S=1
+    ):
         """Perform a change of variables to enforce the box constraints.
 
         Args:
             problem_variables (torch.Tensor): The variables to change.
-            S (float): The saturation value of the amplitudes. Defaults to 1.
+            lower_limit (float or torch.Tensor): The lower bound of the box constraints. Defaults to 0.
+            upper_limit (float or torch.Tensor): The upper bound of the box constraints. Defaults to 1.
+            S (float or torch.tensor): The enforced saturation value. Defaults to 1
 
         Returns:
             torch.Tensor: The changed variables.
         """
-        return 0.5 * problem_variables / S * (
-            self.solution_bounds[1] - self.solution_bounds[0]
-        ) + 0.5 * (self.solution_bounds[1] + self.solution_bounds[0])
+        return 0.5 * problem_variables / S * (upper_limit - lower_limit) + 0.5 * (
+            upper_limit + lower_limit
+        )
 
     def _fit_to_constraints_boxqp(self, c, lower_clamp, upper_clamp):
         """Clamps the values of c to be within the box constraints

--- a/ccvm_simulators/solvers/langevin_solver.py
+++ b/ccvm_simulators/solvers/langevin_solver.py
@@ -346,7 +346,9 @@ class LangevinSolver(CCVMSolver):
 
         # Perform the solve over the specified number of iterations
         for i in range(iterations):
-            c_drift = self.calculate_drift(c, S)
+            c_drift = self.calculate_drift(
+                c, self.solution_bounds[0], self.solution_bounds[1], S
+            )
 
             wiener_increment_c = wiener_dist_c.sample((problem_size,)).transpose(
                 0, 1
@@ -447,7 +449,9 @@ class LangevinSolver(CCVMSolver):
         # Perform the solve with Adam over the specified number of iterations
         for i in range(iterations):
             # Calculate gradient
-            c_grads = self.calculate_grads(c, S)
+            c_grads = self.calculate_grads(
+                c, self.solution_bounds[0], self.solution_bounds[1], S
+            )
 
             # Update biased first moment estimate
             m_c = beta1 * m_c + (1.0 - beta1) * c_grads

--- a/ccvm_simulators/solvers/langevin_solver.py
+++ b/ccvm_simulators/solvers/langevin_solver.py
@@ -160,8 +160,8 @@ class LangevinSolver(CCVMSolver):
 
         Args:
             problem_variables (torch.Tensor): The variables to change.
-            lower_limit (float or torch.Tensor): The lower bound of the box constraints. Defaults to 0.
-            upper_limit (float or torch.Tensor): The upper bound of the box constraints. Defaults to 1.
+            lower_limit (float): The lower bound of the box constraints. Defaults to 0.
+            upper_limit (float): The upper bound of the box constraints. Defaults to 1.
             S (float or torch.tensor): The enforced saturation value. Defaults to 1
 
         Returns:

--- a/ccvm_simulators/solvers/mf_solver.py
+++ b/ccvm_simulators/solvers/mf_solver.py
@@ -219,7 +219,9 @@ class MFSolver(CCVMSolver):
         Returns:
             torch.Tensor: The changed variables.
         """
-        return 0.5 * (problem_variables / S + 1)
+        return 0.5 * problem_variables / S * (
+            self.solution_bounds[1] - self.solution_bounds[0]
+        ) + 0.5 * (self.solution_bounds[1] + self.solution_bounds[0])
 
     def _fit_to_constraints_boxqp(self, mu_tilde, lower_clamp, upper_clamp):
         """Clamps the values of mu_tilde to be within the box constraints
@@ -719,6 +721,7 @@ class MFSolver(CCVMSolver):
         problem_size = instance.problem_size
         self.q_matrix = instance.q_matrix
         self.v_vector = instance.v_vector
+        self.solution_bounds = instance.solution_bounds
 
         # Get solver setup variables
         batch_size = self.batch_size

--- a/ccvm_simulators/solvers/mf_solver.py
+++ b/ccvm_simulators/solvers/mf_solver.py
@@ -216,8 +216,8 @@ class MFSolver(CCVMSolver):
 
         Args:
             problem_variables (torch.Tensor): The variables to change.
-            lower_limit (float or torch.Tensor): The lower bound of the box constraints. Defaults to 0.
-            upper_limit (float or torch.Tensor): The upper bound of the box constraints. Defaults to 1.
+            lower_limit (float): The lower bound of the box constraints. Defaults to 0.
+            upper_limit (float): The upper bound of the box constraints. Defaults to 1.
             S (float or torch.tensor): The enforced saturation value. Defaults to 1
 
         Returns:

--- a/ccvm_simulators/solvers/pumped_langevin_solver.py
+++ b/ccvm_simulators/solvers/pumped_langevin_solver.py
@@ -135,19 +135,23 @@ class PumpedLangevinSolver(CCVMSolver):
 
         return c_grads
 
-    def _change_variables_boxqp(self, problem_variables, S=1):
+    def _change_variables_boxqp(
+        self, problem_variables, lower_limit=0, upper_limit=1, S=1
+    ):
         """Perform a change of variables to enforce the box constraints.
 
         Args:
             problem_variables (torch.Tensor): The variables to change.
-            S (float): The saturation value of the amplitudes. Defaults to 1.
+            lower_limit (float or torch.Tensor): The lower bound of the box constraints. Defaults to 0.
+            upper_limit (float or torch.Tensor): The upper bound of the box constraints. Defaults to 1.
+            S (float or torch.tensor): The enforced saturation value. Defaults to 1
 
         Returns:
             torch.Tensor: The changed variables.
         """
-        return 0.5 * problem_variables / S * (
-            self.solution_bounds[1] - self.solution_bounds[0]
-        ) + 0.5 * (self.solution_bounds[1] + self.solution_bounds[0])
+        return 0.5 * problem_variables / S * (upper_limit - lower_limit) + 0.5 * (
+            upper_limit + lower_limit
+        )
 
     def _fit_to_constraints_boxqp(self, c, lower_clamp, upper_clamp):
         """Clamps the values of c to be within the box constraints

--- a/ccvm_simulators/solvers/pumped_langevin_solver.py
+++ b/ccvm_simulators/solvers/pumped_langevin_solver.py
@@ -142,8 +142,8 @@ class PumpedLangevinSolver(CCVMSolver):
 
         Args:
             problem_variables (torch.Tensor): The variables to change.
-            lower_limit (float or torch.Tensor): The lower bound of the box constraints. Defaults to 0.
-            upper_limit (float or torch.Tensor): The upper bound of the box constraints. Defaults to 1.
+            lower_limit (float): The lower bound of the box constraints. Defaults to 0.
+            upper_limit (float): The upper bound of the box constraints. Defaults to 1.
             S (float or torch.tensor): The enforced saturation value. Defaults to 1
 
         Returns:

--- a/ccvm_simulators/solvers/pumped_langevin_solver.py
+++ b/ccvm_simulators/solvers/pumped_langevin_solver.py
@@ -145,7 +145,9 @@ class PumpedLangevinSolver(CCVMSolver):
         Returns:
             torch.Tensor: The changed variables.
         """
-        return 0.5 * (problem_variables / S + 1)
+        return 0.5 * problem_variables / S * (
+            self.solution_bounds[1] - self.solution_bounds[0]
+        ) + 0.5 * (self.solution_bounds[1] + self.solution_bounds[0])
 
     def _fit_to_constraints_boxqp(self, c, lower_clamp, upper_clamp):
         """Clamps the values of c to be within the box constraints
@@ -476,6 +478,7 @@ class PumpedLangevinSolver(CCVMSolver):
         problem_size = instance.problem_size
         self.q_matrix = instance.q_matrix
         self.v_vector = instance.v_vector
+        self.solution_bounds = instance.solution_bounds
 
         # Get solver setup variables
         batch_size = self.batch_size

--- a/ccvm_simulators/tests/unit/problem_classes/test_problem_instance.py
+++ b/ccvm_simulators/tests/unit/problem_classes/test_problem_instance.py
@@ -206,6 +206,67 @@ class TestProblemInstance(TestCase):
 
         assert torch.equal(problem_instance.scaled_by, expected_scaled_by)
 
+    def test_solution_bounds_valid(self):
+        """Test that valid solution bounds can be set"""
+        lower_bound = 1
+        upper_bound = 10
+        try:
+            problem_instance = ProblemInstance(
+                device=self.device,
+                instance_type=self.instance_type,
+                file_path=self.file_path,
+                solution_bounds=(lower_bound, upper_bound),
+            )
+        except ValueError:
+            self.fail("Solution bounds should be valid, unexpected value error")
+
+    def test_solution_bounds_too_many_values(self):
+        """Test that too many solution bounds values are rejected with the correct error message"""
+        lower_bound = 1
+        upper_bound = 10
+        with self.assertRaises(ValueError) as context:
+            ProblemInstance(
+                device=self.device,
+                instance_type=self.instance_type,
+                file_path=self.file_path,
+                solution_bounds=(lower_bound, upper_bound, 10),
+            )
+        self.assertEqual(
+            str(context.exception),
+            "solution_bounds must be a tuple of size 2, containing the minimum and maximum bounds (inclusive)",
+        )
+
+    def test_solution_bounds_too_few_values(self):
+        """Test that too few solution bounds values are rejected with the correct error message"""
+        lower_bound = 1
+        with self.assertRaises(ValueError) as context:
+            ProblemInstance(
+                device=self.device,
+                instance_type=self.instance_type,
+                file_path=self.file_path,
+                solution_bounds=(lower_bound,),
+            )
+        self.assertEqual(
+            str(context.exception),
+            "solution_bounds must be a tuple of size 2, containing the minimum and maximum bounds (inclusive)",
+        )
+
+    def test_solution_bounds_max_smaller_than_min(self):
+        """Test that a solution bounds max value smaller than the min value is rejected with the correct error message"""
+        lower_bound = 10
+        upper_bound = 1
+        with self.assertRaises(ValueError) as context:
+            ProblemInstance(
+                device=self.device,
+                instance_type=self.instance_type,
+                file_path=self.file_path,
+                solution_bounds=(lower_bound, upper_bound),
+            )
+        self.assertEqual(
+            str(context.exception),
+            "Minimum solution bound must be less than maximum solution bound",
+        )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/ccvm_simulators/tests/unit/solvers/test_mf_solver.py
+++ b/ccvm_simulators/tests/unit/solvers/test_mf_solver.py
@@ -254,6 +254,7 @@ class TestMFSolver(TestCase):
         instance.q_matrix = torch.tensor([[1.0, 2.0], [3.0, 4.0]])
         instance.v_vector = torch.tensor([[5.0, 6.0]])
         instance.problem_size = 2
+        instance.solution_bounds = (0, 1)
         instance.compute_energy.return_value = torch.tensor([[7.0]])
         instance.optimal_sol = random.random()
         instance.device = "cpu"

--- a/ccvm_simulators/tests/unit/solvers/test_mf_solver.py
+++ b/ccvm_simulators/tests/unit/solvers/test_mf_solver.py
@@ -141,6 +141,18 @@ class TestMFSolver(TestCase):
 
         assert torch.equal(changed_variables, expected_values)
 
+    def test_change_variables_boxqp_custom_bounds_valid(self):
+        """Test that change_variables returns correct data when valid parameters are
+        passed"""
+        problem_variables = torch.tensor([[4.0, 4.0], [4.0, 4.0]])
+        changed_variables = self.mf_solver._change_variables_boxqp(
+            problem_variables=problem_variables, lower_limit=0.2, upper_limit=0.8, S=2
+        )
+        # Expected values were manually calculated
+        expected_values = torch.tensor([[1.1, 1.1], [1.1, 1.1]])
+
+        assert torch.equal(changed_variables, expected_values)
+
     def test_fit_to_constraints_boxqp_already_constrained(self):
         """
         Test that fit_to_constraints returns correct data when input parameter to clamp


### PR DESCRIPTION
### Description

The upper and lower limit of the box constraints were being implicitly factored into the equations as though the lower limit was 0 and the upper limit was 1. To make the code more versatile, we've made the equations explicit and added the solution_bounds as a parameter to the ProblemInstance class.


### References

Closes #70 

### Testing

<TBD>

- [ ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not `main`